### PR TITLE
fix(client): map SiYuan BCP 47 lang codes to draw.io locale

### DIFF
--- a/client/PreConfig.js
+++ b/client/PreConfig.js
@@ -14,17 +14,18 @@ if(process.env.NODE_ENV === 'development'){
    */
   // Overrides of global vars need to be pre-loaded
   function getLang(){
-    let lang = parent?.siyuan.config.lang
+    let lang = parent?.siyuan?.config?.lang
 
     if (lang != null)
       {
-        var dash = lang.indexOf('_');
-        
-        if (dash >= 0)
+        // SiYuan 3.7+ uses BCP 47 (zh-CN); older versions use zh_CN. Draw.io expects "zh".
+        var sep = lang.search(/[_-]/);
+
+        if (sep >= 0)
         {
-          lang = lang.substring(0, dash);
+          lang = lang.substring(0, sep);
         }
-        
+
         lang = lang.toLowerCase();
       }
 


### PR DESCRIPTION
## Summary

- Fix draw.io editor showing English when SiYuan UI language is Simplified Chinese (zh-CN)
- Update `getLang()` in `PreConfig.js` to split language codes on both `_` and `-` separators
- Map `zh-CN` to `zh` so draw.io loads `dia_zh.txt` correctly

## Background

SiYuan 3.7+ changed `config.lang` from `zh_CN` to BCP 47 `zh-CN` ([siyuan#17855](https://github.com/siyuan-note/siyuan/issues/17855)). The previous logic only handled underscores, producing `zh-cn` which draw.io does not recognize.

## Test plan

- [x] Set SiYuan language to Simplified Chinese (设置 → 外观 → 语言)
- [x] Open draw.io plugin and create a new diagram
- [x] Verify editor UI is in Chinese (File/Edit/View menus, New Diagram dialog)
- [x] Confirm `urlParams.lang` is `zh` in the draw.io iframe console